### PR TITLE
Add --save and --style args to analyse_results_GaN

### DIFF
--- a/Analysis_Scripts/Styles/pub.mplstyle
+++ b/Analysis_Scripts/Styles/pub.mplstyle
@@ -5,11 +5,17 @@ lines.linewidth : 1
 
 font.size : 7
 axes.labelsize: medium
+axes.labelpad : 1.5
 axes.titlesize : large
 legend.fontsize : medium
 
+axes.linewidth : 1
+grid.linewidth : 0.6
 xtick.direction : in
 ytick.direction : in
+xtick.major.width : 1
+ytick.major.width : 1
+
 
 # In LobsterPy, axis lines through origin use grid settings.
 # This should avoid clutter when grid is also enabled
@@ -21,11 +27,12 @@ axes.prop_cycle: cycler('color', ['e41a1c', '377eb8', '4daf4a', '984ea3', 'ff7f0
 ### autolayout is equivalent to .tight_layout()
 ### - a good default but sometimes we want to get
 ### in there with subplot spacing to use all space
-# figure.autolayout : True
-figure.subplot.right : 0.96
-figure.subplot.bottom : 0.2
+figure.autolayout : False
+figure.subplot.left : 0.16
+figure.subplot.right : 0.97
+figure.subplot.bottom : 0.18
 figure.subplot.top : 0.99
-figure.subplot.left 0.2
+
 
 legend.loc : upper right
 legend.frameon : False

--- a/Analysis_Scripts/Styles/pub.mplstyle
+++ b/Analysis_Scripts/Styles/pub.mplstyle
@@ -1,0 +1,35 @@
+figure.figsize : 2.5, 1.5
+figure.dpi : 400
+
+lines.linewidth : 1
+
+font.size : 7
+axes.labelsize: medium
+axes.titlesize : large
+legend.fontsize : medium
+
+xtick.direction : in
+ytick.direction : in
+
+# In LobsterPy, axis lines through origin use grid settings.
+# This should avoid clutter when grid is also enabled
+grid.color : k
+
+# palettable.colorbrewer.qualitative.Set1_9
+axes.prop_cycle: cycler('color', ['e41a1c', '377eb8', '4daf4a', '984ea3', 'ff7f00', 'ffff33', 'a65628', 'f781bf', '999999'])
+
+### autolayout is equivalent to .tight_layout()
+### - a good default but sometimes we want to get
+### in there with subplot spacing to use all space
+# figure.autolayout : True
+figure.subplot.right : 0.96
+figure.subplot.bottom : 0.2
+figure.subplot.top : 0.99
+figure.subplot.left 0.2
+
+legend.loc : upper right
+legend.frameon : False
+legend.borderpad : 1.2
+
+# Embed text, easier to edit with vector graphics software
+pdf.fonttype : 42


### PR DESCRIPTION
These can be used with Analysis_Scripts/Styles/pub.mplstyle to make small publication-friendly plots.

I'm not sure how interesting/useful it would be to extend this to the other scripts.

I've also found it helpful to tweak lobsterpy to disable plt.show() if files are being saved, this makes the development loop a bit smoother.